### PR TITLE
fix:quilleditor をコンポーネントとして切り出す

### DIFF
--- a/app/create/components/QuillEditor.tsx
+++ b/app/create/components/QuillEditor.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import ReactQuill, { Quill } from "react-quill";
+import "react-quill/dist/quill.snow.css";
+import {
+  FaBold,
+  FaItalic,
+  FaUnderline,
+  FaStrikethrough,
+  FaMinus,
+  FaPlus,
+} from "react-icons/fa";
+
+// サイズフォーマットの登録
+const Size = Quill.import("formats/size");
+Size.whitelist = ["small", "normal", "large", "huge"];
+Quill.register(Size, true);
+
+function QuillEditor() {
+  const [content, setContent] = useState("");
+  const quillRef = useRef<ReactQuill>(null);
+
+  const formats = ["bold", "italic", "underline", "strike"];
+
+  const handleFormat = (format: string) => {
+    if (quillRef.current) {
+      const quill = quillRef.current.getEditor();
+      quill.format(format, !quill.getFormat()[format]);
+    }
+  };
+
+  const adjustFontSize = (increase: boolean) => {
+    if (quillRef.current) {
+      const quill = quillRef.current.getEditor();
+      const currentSize = quill.getFormat().size || "normal";
+      const sizes = ["small", "normal", "large", "huge"];
+      const currentIndex = sizes.indexOf(currentSize);
+
+      if (increase && currentIndex < sizes.length - 1) {
+        quill.format("size", sizes[currentIndex + 1]);
+      } else if (!increase && currentIndex > 0) {
+        quill.format("size", sizes[currentIndex - 1]);
+      }
+    }
+  };
+
+  return (
+    <div className='flex flex-col lg:flex-row w-full space-y-4 lg:space-y-0 lg:space-x-4'>
+      {/* サイドバー */}
+      <aside className='w-full lg:w-[80px] order-2 lg:order-none'>
+        <div className='bg-gray-300 rounded-xl p-2 h-[50px] lg:h-[500px] flex flex-row lg:flex-col justify-between items-center'>
+          {/* フォーマットボタン */}
+          {formats.map((format, i) => (
+            <button
+              key={i}
+              onClick={() => handleFormat(format)}
+              className='w-10 h-10 lg:w-14 lg:h-14 p-2 hover:bg-gray-400 rounded flex items-center justify-center mb-2'
+            >
+              {format === "bold" && <FaBold className='text-lg lg:text-xl' />}
+              {format === "italic" && (
+                <FaItalic className='text-lg lg:text-xl' />
+              )}
+              {format === "underline" && (
+                <FaUnderline className='text-lg lg:text-xl' />
+              )}
+              {format === "strike" && (
+                <FaStrikethrough className='text-lg lg:text-xl' />
+              )}
+            </button>
+          ))}
+          {/* 文字サイズ調整ボタン */}
+          <button
+            onClick={() => adjustFontSize(true)}
+            className='w-10 h-10 lg:w-14 lg:h-14 p-2 hover:bg-gray-400 rounded flex items-center justify-center mb-2'
+          >
+            <FaPlus className='text-lg lg:text-xl' />
+          </button>
+          <button
+            onClick={() => adjustFontSize(false)}
+            className='w-10 h-10 lg:w-14 lg:h-14 p-2 hover:bg-gray-400 rounded flex items-center justify-center'
+          >
+            <FaMinus className='text-lg lg:text-xl' />
+          </button>
+        </div>
+      </aside>
+      <div className='flex-grow'>
+        <ReactQuill
+          ref={quillRef}
+          value={content}
+          onChange={setContent}
+          modules={{ toolbar: false }}
+          formats={[...formats, "size"]}
+          className='h-[500px] bg-gray-100 rounded-xl'
+        />
+      </div>
+    </div>
+  );
+}
+
+export default QuillEditor;

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,60 +1,15 @@
-"use client";
-import React, { useRef, useState } from "react";
-import "react-quill/dist/quill.snow.css";
-import {
-  FaBold,
-  FaItalic,
-  FaUnderline,
-  FaStrikethrough,
-  FaMinus,
-  FaPlus,
-} from "react-icons/fa";
-import ReactQuill, { Quill } from "react-quill";
+import dynamic from "next/dynamic";
+import React from "react";
 
-// サイズフォーマットの登録
-const Size = Quill.import("formats/size");
-Size.whitelist = ["small", "normal", "large", "huge"];
-Quill.register(Size, true);
+// React-Quillを動的にインポートし、SSRを無効にする
+const QuillEditor = dynamic(() => import("./components/QuillEditor"), {
+  ssr: false,
+});
 
 function CreatePage() {
-  const [content, setContent] = useState("");
-  // ReactQuillコンポーネントへの参照を取得
-  const quillRef = useRef<ReactQuill>(null);
-
-  const formats = ["bold", "italic", "underline", "strike"];
-
-  // アイコンを押下した際にフォーマットを適用する処理
-  const handleFormat = (format: string) => {
-    if (quillRef.current) {
-      // Quillエディタのインスタンスを取得
-      const quill = quillRef.current.getEditor();
-      quill.format(format, !quill.getFormat()[format]);
-    }
-  };
-
-  // フォントサイズを調整する処理
-  const adjustFontSize = (increase: boolean) => {
-    if (quillRef.current) {
-      // Quillエディタのインスタンスを取得
-      const quill = quillRef.current.getEditor();
-      // 現在選択されているテキストのサイズを取得（デフォルトは"nomal"）
-      const currentSize = quill.getFormat().size || "normal";
-      const sizes = ["small", "normal", "large", "huge"];
-      const currentIndex = sizes.indexOf(currentSize);
-
-      // フォントサイズを変更する処理
-      if (increase && currentIndex < sizes.length - 1) {
-        quill.format("size", sizes[currentIndex + 1]);
-      } else if (!increase && currentIndex > 0) {
-        quill.format("size", sizes[currentIndex - 1]);
-      }
-    }
-  };
-
   return (
     <div className='min-h-screen flex flex-col'>
       {/* ヘッダー*/}
-      {/* TODO:ナビゲーションバーコンポーネントに差し替え */}
       <header className='bg-gray-300 h-20 sm:h-32 md:h-40 w-full'>
         ナビゲーションバー
       </header>
@@ -62,50 +17,11 @@ function CreatePage() {
       <div className='flex-grow container mx-auto'>
         <main className='px-4'>
           <div className='flex-grow justify-center items-center h-40'>
-            <h1 className=' text-gray-300 leading-normal text-center text-4xl sm:text-5xl md:text-6xl pt-4 font-bold'>
+            <h1 className='text-gray-300 leading-normal text-center text-4xl sm:text-5xl md:text-6xl pt-4 font-bold'>
               Create Blog
             </h1>
           </div>
           <div className='flex flex-col lg:flex-row w-full'>
-            {/* サイドバー */}
-            <aside className='w-full lg:w-[120px] lg:pt-[60px] order-2 lg:order-none'>
-              <div className='bg-gray-300 rounded-xl p-2 h-[50px] lg:h-[600px] flex flex-row lg:flex-col justify-between items-center'>
-                {/* フォーマットボタン */}
-                {formats.map((format, i) => (
-                  <button
-                    key={i}
-                    onClick={() => handleFormat(format)}
-                    className='w-12 h-12 lg:w-16 lg:h-16 p-2 hover:bg-gray-400 rounded flex items-center justify-center'
-                  >
-                    {format === "bold" && (
-                      <FaBold className='text-xl lg:text-2xl' />
-                    )}
-                    {format === "italic" && (
-                      <FaItalic className='text-xl lg:text-2xl' />
-                    )}
-                    {format === "underline" && (
-                      <FaUnderline className='text-xl lg:text-2xl' />
-                    )}
-                    {format === "strike" && (
-                      <FaStrikethrough className='text-xl lg:text-2xl' />
-                    )}
-                  </button>
-                ))}
-                {/* 文字サイズ調整ボタン */}
-                <button
-                  onClick={() => adjustFontSize(true)}
-                  className='w-12 h-12 lg:w-16 lg:h-16 p-2 hover:bg-gray-400 rounded flex items-center justify-center'
-                >
-                  <FaPlus className='text-xl lg:text-2xl' />
-                </button>
-                <button
-                  onClick={() => adjustFontSize(false)}
-                  className='w-12 h-12 lg:w-16 lg:h-16 p-2 hover:bg-gray-400 rounded flex items-center justify-center'
-                >
-                  <FaMinus className='text-xl lg:text-2xl' />
-                </button>
-              </div>
-            </aside>
             {/* メインコンテンツ */}
             <section className='flex-grow lg:ml-16 mr-0 lg:mr-4 order-1 lg:order-2 w-full'>
               {/* タイトル */}
@@ -113,7 +29,7 @@ function CreatePage() {
                 <input
                   type='text'
                   placeholder='Title'
-                  className='w-full h-12 sm:h-16 text-[clamp(36px,4.5vw,64px)] placeholder:font-bold text-gray-500 focus:outline-none '
+                  className='w-full h-12 sm:h-16 text-[clamp(36px,4.5vw,64px)] placeholder:font-bold text-gray-500 focus:outline-none'
                 />
               </div>
               {/* アップロードエリア */}
@@ -127,14 +43,7 @@ function CreatePage() {
               </div>
               {/* 本文エリア */}
               <div className='lg:mb-4'>
-                <ReactQuill
-                  ref={quillRef}
-                  value={content}
-                  onChange={setContent}
-                  modules={{ toolbar: false }}
-                  formats={[...formats, "size"]}
-                  className='h-[500px] mb-1 bg-gray-100 rounded-xl'
-                />
+                <QuillEditor />
               </div>
             </section>
           </div>


### PR DESCRIPTION
## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- create ページでエラーが出ていたので、解消するために quillediter をコンポーネントとして切り出しています。、
- quillEditor と Sidebar を分けることがどうやっても難しく、figmaのデザインとサイドバーの位置が異なっておりますが、動作はするので一旦これでこれで行かせてくださいmm
- 以下のエラーは調査を重ねましたが対処不可のため（おそらくライブラリの問題）、動くことは動くので、このままとします
  - ```[Deprecation] Listener added for a 'DOMNodeInserted' mutation event. Support for this event type has been removed, and this event will no longer be fired. ```


## レビュー観点（レビューをする際に見てほしい点など）



https://github.com/user-attachments/assets/3b592014-b4e1-411e-9fc6-617f048b3617


