### PR TITLE
[#7,#8,#9]ブログページのタイトル、本文、画像をsupabaseへ登録できるようにする

### DIFF
--- a/app/create/components/ImageUploadeSection.tsx
+++ b/app/create/components/ImageUploadeSection.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import useImageUploder from "@/app/hooks/useImageUploder";
+import React, { useRef, useState } from "react";
+
+export default function ImageUploadeSection() {
+  // 画像アップロードのカスタムフックを使用
+  const { uploading, error, handleFileChange } = useImageUploder();
+
+  // ボタンクリック時にファイル選択ダイアログを開くためにinput要素を参照
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  console.log(uploading);
+
+  return (
+    <div className='mb-5'>
+      <div className='w-full h-[clamp(200px,30vw,400px)] border-2 border-dashed border-gray-300 rounded-xl flex flex-col items-center justify-center'>
+        <div className='my-8 text-7xl text-gray-300'>↑</div>
+        <input
+          type='file'
+          accept='image/*'
+          onChange={handleFileChange}
+          ref={fileInputRef}
+          style={{ display: "none" }}
+        />
+        {/* {file && <p className='mb-2'>Selected file: {file.name}</p>} */}
+        <button
+          onClick={handleButtonClick}
+          disabled={uploading}
+          className='bg-blue-400 w-[clamp(100px,30vw,200px)] h-[clamp(40px,10vw,50px)] text-[clamp(12px,3vw,20px)] mb-5 rounded-full flex items-center justify-center'
+        >
+          {uploading ? "uploading..." : "Upload Image"}
+        </button>
+        {error && <p className='text-red-500 mt-2'>{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/app/create/components/ImageUploadeSection.tsx
+++ b/app/create/components/ImageUploadeSection.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import useImageUploder from "@/app/hooks/useImageUploder";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 
-export default function ImageUploadeSection() {
+type ImageUploadeSectionProps = {
+  onImageUpload: (url: string) => void;
+};
+
+export default function ImageUploadeSection({
+  onImageUpload,
+}: ImageUploadeSectionProps) {
   // 画像アップロードのカスタムフックを使用
-  const { uploading, error, handleFileChange } = useImageUploder();
+  const { uploading, error, handleFileChange, uploadedImageUrl } =
+    useImageUploder();
 
   // ボタンクリック時にファイル選択ダイアログを開くためにinput要素を参照
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -13,6 +20,13 @@ export default function ImageUploadeSection() {
   const handleButtonClick = () => {
     fileInputRef.current?.click();
   };
+
+  // 画像URLが変更されたときに親コンポーネントに通知
+  useEffect(() => {
+    if (uploadedImageUrl) {
+      onImageUpload(uploadedImageUrl);
+    }
+  }, [uploadedImageUrl, onImageUpload]);
 
   console.log(uploading);
 

--- a/app/create/components/QuillEditor.tsx
+++ b/app/create/components/QuillEditor.tsx
@@ -17,8 +17,12 @@ const Size = Quill.import("formats/size");
 Size.whitelist = ["small", "normal", "large", "huge"];
 Quill.register(Size, true);
 
-function QuillEditor() {
-  const [content, setContent] = useState("");
+type QuillEditorProps = {
+  content: string;
+  setContent: (content: string) => void;
+};
+
+function QuillEditor({ content, setContent }: QuillEditorProps) {
   const quillRef = useRef<ReactQuill>(null);
 
   const formats = ["bold", "italic", "underline", "strike"];

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import ImageUploadeSection from "@/app/create/components/ImageUploadeSection";
+import { supabase } from "@/app/utils/supabase";
 import dynamic from "next/dynamic";
 import React, { useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 // React-Quillを動的にインポートし、SSRを無効にする
 const QuillEditor = dynamic(() => import("./components/QuillEditor"), {
@@ -10,6 +12,47 @@ const QuillEditor = dynamic(() => import("./components/QuillEditor"), {
 });
 
 function CreatePage() {
+  // タイトル、本文、画像のURLを管理するステート
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // 画像がアップロードされたときに呼ばれるコールバック関数
+  const handleImageUpload = (url: string) => {
+    setImageUrl(url);
+  };
+
+  // 投稿をデータベースに保存する処理
+  const handleSavePost = async () => {
+    if (!title || !content || !imageUrl) {
+      setError("すべてのフィールドを入力してください。");
+      return;
+    }
+
+    const { error } = await supabase.from("posts").insert([
+      {
+        id: uuidv4(),
+        user_id: 1, // ユーザーIDは仮で1を設定（後で実際のユーザーIDを取得するように変更）
+        category_id: 1, // カテゴリーIDについても別途実装
+        title: title,
+        content: content,
+        image_path: imageUrl,
+      },
+    ]);
+
+    if (error) {
+      setError(`保存に失敗しました: ${error.message}`);
+    } else {
+      setError(null);
+      alert("投稿が保存されました！");
+      // 投稿が保存されたらフォームをクリア
+      setTitle("");
+      setContent("");
+      setImageUrl(null);
+    }
+  };
+
   return (
     <div className='min-h-screen flex flex-col'>
       {/* ヘッダー*/}
@@ -31,16 +74,29 @@ function CreatePage() {
               <div className='my-10'>
                 <input
                   type='text'
+                  value={title}
                   placeholder='Title'
+                  onChange={(e) => setTitle(e.target.value)}
                   className='w-full h-12 sm:h-16 text-[clamp(36px,4.5vw,64px)] placeholder:font-bold text-gray-500 focus:outline-none'
                 />
               </div>
               {/* アップロードエリア */}
-              <ImageUploadeSection />
+              {/* URLを設定 */}
+              <ImageUploadeSection onImageUpload={handleImageUpload} />
               {/* 本文エリア */}
               <div className='lg:mb-4'>
-                <QuillEditor />
+                {/* 本文を設定 */}
+                <QuillEditor content={content} setContent={setContent} />
               </div>
+              <div className='flex justify-end'>
+                <button
+                  onClick={handleSavePost}
+                  className='bg-blue-500 text-white px-4 py-2 rounded'
+                >
+                  Save Post
+                </button>
+              </div>
+              {error && <p className='text-red-500 mt-2'>{error}</p>}
             </section>
           </div>
         </main>

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -33,8 +33,8 @@ function CreatePage() {
     const { error } = await supabase.from("posts").insert([
       {
         id: uuidv4(),
-        user_id: 1, // ユーザーIDは仮で1を設定（後で実際のユーザーIDを取得するように変更）
-        category_id: 1, // カテゴリーIDについても別途実装
+        user_id: 1, // TODO:ユーザーIDは仮で1を設定（後で実際のユーザーIDを取得するように変更）
+        category_id: 1, // TODO:カテゴリーIDについても別途実装
         title: title,
         content: content,
         image_path: imageUrl,
@@ -89,6 +89,7 @@ function CreatePage() {
                 <QuillEditor content={content} setContent={setContent} />
               </div>
               <div className='flex justify-end'>
+                {/* TODO:ボタンは別途共通コンポーネントを採用 */}
                 <button
                   onClick={handleSavePost}
                   className='bg-blue-500 text-white px-4 py-2 rounded'

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+
+import ImageUploadeSection from "@/app/create/components/ImageUploadeSection";
 import dynamic from "next/dynamic";
-import React from "react";
+import React, { useState } from "react";
 
 // React-Quillを動的にインポートし、SSRを無効にする
 const QuillEditor = dynamic(() => import("./components/QuillEditor"), {
@@ -33,14 +36,7 @@ function CreatePage() {
                 />
               </div>
               {/* アップロードエリア */}
-              <div className='mb-5'>
-                <div className='w-full h-[clamp(200px,30vw,400px)] border-2 border-dashed border-gray-300 rounded-xl flex flex-col items-center justify-center'>
-                  <div className='my-8 text-7xl text-gray-300'>↑</div>
-                  <button className='bg-blue-400 w-[clamp(100px,30vw,200px)] h-[clamp(40px,10vw,50px)] text-[clamp(12px,3vw,20px)] mb-5 rounded-full flex items-center justify-center'>
-                    Upload Image
-                  </button>
-                </div>
-              </div>
+              <ImageUploadeSection />
               {/* 本文エリア */}
               <div className='lg:mb-4'>
                 <QuillEditor />

--- a/app/hooks/useImageUploder.tsx
+++ b/app/hooks/useImageUploder.tsx
@@ -1,0 +1,42 @@
+import { supabase } from "@/app/utils/supabase";
+import React, { useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+function useImageUploder() {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile && selectedFile.type.match("image.*")) {
+      await handleUpload(selectedFile); // ファイルが選択された後にアップロードを開始
+    } else {
+      setError("画像ファイルを選択してください");
+    }
+  };
+
+  const handleUpload = async (file: File) => {
+    setUploading(true);
+    setError(null);
+    try {
+      // ファイルをアップロードする処理
+      const fileExtention = file.name.split(".").pop();
+      const fileName = `${uuidv4()}.${fileExtention}`;
+      const { error: uploadError } = await supabase.storage
+        .from("public-image-bucket")
+        .upload(`img/${fileName}`, file);
+      if (uploadError) throw uploadError;
+      console.log("Uploaded successful:", fileName);
+    } catch (error) {
+      if (error instanceof Error) {
+        setError(`Upload failed: ${error.message}`);
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return { uploading, error, handleFileChange, handleUpload };
+}
+
+export default useImageUploder;

--- a/app/hooks/useImageUploder.tsx
+++ b/app/hooks/useImageUploder.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 function useImageUploder() {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadedImageUrl, setuploadedImageUrl] = useState<string | null>(null);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
@@ -27,6 +28,15 @@ function useImageUploder() {
         .upload(`img/${fileName}`, file);
       if (uploadError) throw uploadError;
       console.log("Uploaded successful:", fileName);
+      // アップロードした画像のURLを取得
+      const {
+        data: { publicUrl },
+      } = await supabase.storage
+        .from("public-image-bucket")
+        .getPublicUrl(`img/${fileName}`);
+
+      setuploadedImageUrl(publicUrl);
+      console.log("Public URL:", publicUrl);
     } catch (error) {
       if (error instanceof Error) {
         setError(`Upload failed: ${error.message}`);
@@ -36,7 +46,7 @@ function useImageUploder() {
     }
   };
 
-  return { uploading, error, handleFileChange, handleUpload };
+  return { uploading, error, uploadedImageUrl, handleFileChange, handleUpload };
 }
 
 export default useImageUploder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.2.1",
-        "react-quill": "^2.0.0"
+        "react-quill": "^2.0.0",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/uuid": "^10.0.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^8",
         "eslint-config-next": "14.2.3",
@@ -596,6 +598,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.12",
@@ -5307,6 +5315,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.2.1",
-    "react-quill": "^2.0.0"
+    "react-quill": "^2.0.0",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",


### PR DESCRIPTION
close #7 
close #8
close #9  

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- ブログのタイトル、本文、画像をsupabase へアップロードできるようにしております。
- submitボタンは一時的に右下に作成してますが、後ほど共通コンポーネントに切り替えるリファクタをします
- 画像は、supabase の strageに、public-image-bucket という名前でバケットを作成しております。
  - https://supabase.com/dashboard/project/enzejypzafacxwjdajnd/storage/buckets/public-image-bucket 
- ユーザーidとカテゴリーidは別途設定が必要なため、現在は「1」 でハードコードしています。

## レビュー観点（レビューをする際に見てほしい点など）

- 動作が問題ないか

## スクリーンショット
https://github.com/user-attachments/assets/835e13a9-2793-4af7-a546-645462322cde

