### PR TITLE
🎨 CardItem をNextLinkにして指定のページへのリンク先を設定

### DIFF
--- a/app/components/CardItem/CardItem.tsx
+++ b/app/components/CardItem/CardItem.tsx
@@ -1,6 +1,7 @@
-import { FC, ReactNode } from 'react';
-import styles from './carditem.module.css'
-import Image from 'next/image';
+import { FC } from "react";
+import styles from "./carditem.module.css";
+import Image from "next/image";
+import Link from "next/link";
 
 type Props = {
   id?: number;
@@ -11,16 +12,26 @@ type Props = {
   author?: string;
   description?: string;
   alt?: string | any;
-}
+  page?: string;
+};
 
-
-export const CardItem: FC<Props> = ((props) => {
-  const { id, imageUrl, alt, title, date, category, author, description } = props;
-
+export const CardItem: FC<Props> = (props) => {
+  const {
+    id,
+    imageUrl,
+    alt,
+    title,
+    date,
+    category,
+    author,
+    description,
+    page,
+  } = props;
+  const url = page || "blog";
   return (
     <>
       <li key={id} className={styles.postItem}>
-        <a href="">
+        <Link href={`/${url}/${id}`}>
           <Image src={imageUrl} alt={alt} width="400" height="100" />
           <div className={styles.postItem_inner}>
             <div className={`${styles.title} mb-8`}>
@@ -31,14 +42,10 @@ export const CardItem: FC<Props> = ((props) => {
               <p className={styles.txtBlue}>{author}</p>
               <p className={`${styles.time} ${styles.txtBlue}`}>{date}</p>
             </div>
-            <p className="description">
-              {description}
-            </p>
+            <p className="description">{description}</p>
           </div>
-        </a>
+        </Link>
       </li>
-
     </>
-  )
-
-})
+  );
+};

--- a/app/components/CardItem/CardItem.tsx
+++ b/app/components/CardItem/CardItem.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 type Props = {
-  id?: number;
+  id: string;
   title: string;
   date: string;
   imageUrl: string;
@@ -40,7 +40,7 @@ export const CardItem: FC<Props> = (props) => {
   const url = page || "blog";
   return (
     <>
-      <li key={id} className={styles.postItem}>
+      <li className={styles.postItem}>
         <Link href={`/${url}/${id}`}>
           <figure>
             {imageUrl && (

--- a/app/components/CardItem/CardItem.tsx
+++ b/app/components/CardItem/CardItem.tsx
@@ -15,6 +15,16 @@ type Props = {
   page?: string;
 };
 
+const sanitizeAndTruncate = (text: string): string => {
+  // HTMLタグを除去
+  const sanitizedText = text.replace(/<\/?[^>]+(>|$)/g, "");
+
+  // 文字数を制限し、38文字以上なら...を追加
+  return sanitizedText.length > 38
+    ? `${sanitizedText.substring(0, 38)}...`
+    : sanitizedText;
+};
+
 export const CardItem: FC<Props> = (props) => {
   const {
     id,
@@ -32,7 +42,11 @@ export const CardItem: FC<Props> = (props) => {
     <>
       <li key={id} className={styles.postItem}>
         <Link href={`/${url}/${id}`}>
-          <Image src={imageUrl} alt={alt} width="400" height="100" />
+          <figure>
+            {imageUrl && (
+              <Image src={imageUrl} alt={alt} width="400" height="100" />
+            )}
+          </figure>
           <div className={styles.postItem_inner}>
             <div className={`${styles.title} mb-8`}>
               <h3>{title}</h3>
@@ -42,7 +56,9 @@ export const CardItem: FC<Props> = (props) => {
               <p className={styles.txtBlue}>{author}</p>
               <p className={`${styles.time} ${styles.txtBlue}`}>{date}</p>
             </div>
-            <p className="description">{description}</p>
+            <p className="description">
+              {description && sanitizeAndTruncate(description)}
+            </p>
           </div>
         </Link>
       </li>

--- a/app/components/CardItem/CardItem.tsx
+++ b/app/components/CardItem/CardItem.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 type Props = {
-  id: string;
+  id: string | number;
   title: string;
   date: string;
   imageUrl: string;

--- a/app/components/CardItem/carditem.module.css
+++ b/app/components/CardItem/carditem.module.css
@@ -1,6 +1,5 @@
-
-.txtBlue{
-  color: #18A0FB;
+.txtBlue {
+  color: #18a0fb;
 }
 
 .postItem {
@@ -11,10 +10,22 @@
   margin-bottom: 40px;
 }
 
-@media screen and (max-width:767px){
-  .postItem{
+@media screen and (max-width: 767px) {
+  .postItem {
     width: 48%;
   }
+}
+
+.postItem figure {
+  width: 100%;
+  aspect-ratio: 1.5 /1;
+  overflow: hidden;
+}
+
+.postItem figure img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .postItem .title {
@@ -29,8 +40,7 @@
   margin-bottom: 8px;
 }
 
-
-@media screen and (max-width:420px){
+@media screen and (max-width: 420px) {
   .postWrap {
     display: block;
   }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -92,6 +92,7 @@ const page = () => {
                     author={item.author}
                     description={item.description}
                     alt="アイキャッチ"
+                    page="create"
                   />
                 ))}
               </ul>


### PR DESCRIPTION
close #〇〇

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- CardItem をaタグから NextLinkに変更。
- homeからは /blog/[id]に遷移します。
- profileからは /create/[id] に遷移します。
	- 今後変更あるかも？ 
	- 現在はそのようなページが存在しないので 404 になります。
- 画像サイズを一定のサイズになるようにしました。
- description部分はblogページのコンテンツを意識して、HTMLタグを除去して38文字以上の長さになった場合は ... になるように変更
- なぜかCardItemコンポーネントのkeyが残っていたので削除