### PR TITLE
Headerをコンポーネントに差し替え

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,7 +7,7 @@ import { CommonContext } from "../contexts/CommonContext";
 
 type HeaderProps = {
   page: string;
-  onClick: () => void;
+  onClick?: () => void;
 };
 
 const Header = (props: HeaderProps) => {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import React, { useState, useContext } from "react";
 
 import { poppins } from "../utils/fonts";
@@ -6,21 +6,25 @@ import { HeaderButton } from "./HeaderButton";
 import { CommonContext } from "../contexts/CommonContext";
 
 type HeaderProps = {
-  page: string
+  page: string;
+  onClick: () => void;
 };
 
 const Header = (props: HeaderProps) => {
-  const { page } = props;
+  const { page, onClick } = props;
   const context = useContext(CommonContext);
   const { signInFlag } = context;
 
   const headerButtonChange = () => {
-    if( page === 'Write Blog'){
-      return [ HeaderButton('Home', 'hidden md:block'), HeaderButton('Publish') ]
+    if (page === "Write Blog") {
+      return [
+        HeaderButton("Home", "hidden md:block"),
+        HeaderButton("Publish", undefined, undefined, onClick),
+      ];
     } else {
-      return [ HeaderButton('Home', 'hidden md:block'), HeaderButton('Create') ]
+      return [HeaderButton("Home", "hidden md:block"), HeaderButton("Create")];
     }
-  }
+  };
 
   const [navFlag, setNavFlag] = useState<boolean>(false);
   const navOpen = () => setNavFlag(!navFlag);
@@ -28,14 +32,17 @@ const Header = (props: HeaderProps) => {
   return (
     <>
       {/* header */}
-      <div className={`
+      <div
+        className={`
         w-full
         fixed
         z-100
         top-0
         left-0
-      `}>
-        <div className={`
+      `}
+      >
+        <div
+          className={`
           w-full
           bg-[#d9d9d9]
           relative
@@ -44,7 +51,8 @@ const Header = (props: HeaderProps) => {
           md:h-[90px]
         `}
         >
-          <p className={`
+          <p
+            className={`
             ${poppins.className}
             text-[34px]
             text-[#6b6b6b]
@@ -57,8 +65,12 @@ const Header = (props: HeaderProps) => {
             left-[calc(100vw*(68/750))]
 
             md:left-[50px]
-          `}>LOGO</p>
-          <div className={`
+          `}
+          >
+            LOGO
+          </p>
+          <div
+            className={`
             absolute
             top-[50%]
             right-0
@@ -73,7 +85,9 @@ const Header = (props: HeaderProps) => {
           `}
           >
             {headerButtonChange()}
-            {signInFlag? HeaderButton('Logout', 'hidden md:block') : HeaderButton('Sign In', 'hidden md:block')}
+            {signInFlag
+              ? HeaderButton("Logout", "hidden md:block")
+              : HeaderButton("Sign In", "hidden md:block")}
           </div>
         </div>
       </div>
@@ -92,19 +106,27 @@ const Header = (props: HeaderProps) => {
           flex
           flex-col
           transform
-          ${navFlag ? 'translate-x-0 opacity-[1]' : 'translate-x-[100%] opacity-[0]'}
+          ${
+            navFlag
+              ? "translate-x-0 opacity-[1]"
+              : "translate-x-[100%] opacity-[0]"
+          }
           md:hidden
         `}
         style={{
-          transition: 'opacity .6s cubic-bezier(0.16, 1, 0.3, 1), transform .6s cubic-bezier(0.16, 1, 0.3, 1)'
+          transition:
+            "opacity .6s cubic-bezier(0.16, 1, 0.3, 1), transform .6s cubic-bezier(0.16, 1, 0.3, 1)",
         }}
       >
-        {HeaderButton('Home', 'mx-auto')}
-        {signInFlag? HeaderButton('Logout', 'mx-[auto] mt-[40px]') : HeaderButton('Sign In', 'mx-[auto] mt-[40px]')}
+        {HeaderButton("Home", "mx-auto")}
+        {signInFlag
+          ? HeaderButton("Logout", "mx-[auto] mt-[40px]")
+          : HeaderButton("Sign In", "mx-[auto] mt-[40px]")}
       </div>
 
       {/* hamburger */}
-      <button className={`
+      <button
+        className={`
           fixed
           z-110
           top-0
@@ -116,51 +138,61 @@ const Header = (props: HeaderProps) => {
 
           md:hidden
         `}
-        aria-label='hamburger'
+        aria-label="hamburger"
         onClick={() => navOpen()}
       >
-        <div className={`
+        <div
+          className={`
           w-[36px]
           h-[24px]
           my-auto
           relative
-        `}>
-          <div className={`
+        `}
+        >
+          <div
+            className={`
               w-[100%]
               h-[3px]
               bg-black
               absolute
               left-0
-              ${navFlag ? 'top-[calc(50%-1.5px)] rotate-[45deg]' : 'top-[0]'}
+              ${navFlag ? "top-[calc(50%-1.5px)] rotate-[45deg]" : "top-[0]"}
             `}
             style={{
-              transition: 'transform .6s cubic-bezier(0.16, 1, 0.3, 1)'
+              transition: "transform .6s cubic-bezier(0.16, 1, 0.3, 1)",
             }}
           ></div>
-          <div className={`
+          <div
+            className={`
             w-[100%]
             h-[3px]
             bg-black
             absolute
             left-0
             top-[calc(50%-1.5px)]
-            ${navFlag ? 'opacity-[0]' : 'opacity-[1]'}
+            ${navFlag ? "opacity-[0]" : "opacity-[1]"}
             `}
             style={{
-              transition: 'opacity .6s cubic-bezier(0.16, 1, 0.3, 1)'
-            }}>
-          </div>
-          <div className={`
+              transition: "opacity .6s cubic-bezier(0.16, 1, 0.3, 1)",
+            }}
+          ></div>
+          <div
+            className={`
             w-[100%]
             h-[3px]
             bg-black
             absolute
             left-0
-            ${navFlag ? 'bottom-[calc(50%-1.5px)] rotate-[-45deg]' : 'bottom-[0]'}
+            ${
+              navFlag
+                ? "bottom-[calc(50%-1.5px)] rotate-[-45deg]"
+                : "bottom-[0]"
+            }
             `}
             style={{
-              transition: 'transform .6s cubic-bezier(0.16, 1, 0.3, 1)'
-            }}></div>
+              transition: "transform .6s cubic-bezier(0.16, 1, 0.3, 1)",
+            }}
+          ></div>
         </div>
       </button>
     </>

--- a/app/components/HeaderButton.tsx
+++ b/app/components/HeaderButton.tsx
@@ -1,14 +1,18 @@
 import React, { useState, useContext } from "react";
-import Link from 'next/link';
+import Link from "next/link";
 
 import Image from "next/image";
-import PenLogo from '../../public/images/pen_logo.svg';
-import UserLogo from '../../public/images/user_logo.svg';
+import PenLogo from "../../public/images/pen_logo.svg";
+import UserLogo from "../../public/images/user_logo.svg";
 import { poppins } from "../utils/fonts";
 import { CommonContext } from "../contexts/CommonContext";
 
-
-export const HeaderButton = (name: string, button?: string, p?: string) => {
+export const HeaderButton = (
+  name: string,
+  button?: string,
+  p?: string,
+  onClick?: () => void
+) => {
   const context = useContext(CommonContext);
   const { signInFlag, setSignInFlag, signInOpen } = context;
 
@@ -17,12 +21,13 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
   const handleLogout = (e: React.FormEvent) => {
     e.preventDefault();
 
-    setSignInFlag(!signInFlag)
-  }
+    setSignInFlag(!signInFlag);
+  };
 
-  if( name === 'Create'){
+  if (name === "Create") {
     return (
-      <Link className={`
+      <Link
+        className={`
           w-fit
           h-fit
           bg-[#383838]
@@ -38,7 +43,7 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           md:ml-[24px]
           ${button}
         `}
-        key='Create'
+        key="Create"
         href="./create"
       >
         <Image
@@ -54,20 +59,25 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           src={PenLogo}
           alt="PenLogo"
         />
-        <p className={`
+        <p
+          className={`
           ${poppins.className}
           text-white
           text-[14px]
 
           md:text-[14px]
           ${p}
-        `}>Create</p>
+        `}
+        >
+          Create
+        </p>
       </Link>
-    )
+    );
   }
-  if( name === 'Sign In'){
+  if (name === "Sign In") {
     return (
-      <button className={`
+      <button
+        className={`
           w-fit
           h-fit
           bg-[#d9d9d9]
@@ -81,23 +91,29 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           md:ml-[24px]
           ${button}
         `}
-        key='Sign In'
+        key="Sign In"
         onClick={() => signInOpen()}
       >
-        <p className={`
+        <p
+          className={`
           ${poppins.className}
           text-[#383838]
           text-[14px]
 
           md:text-[14px]
           ${p}
-        `}>Sign In</p>
+        `}
+        >
+          Sign In
+        </p>
       </button>
-    )
+    );
   }
-  if( name === 'Publish'){
+  if (name === "Publish") {
     return (
-      <button className={`
+      <button
+        onClick={onClick}
+        className={`
           ${button}
           w-fit
           h-fit
@@ -111,22 +127,27 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
 
           md:ml-[24px]
         `}
-        key='Publish'
+        key="Publish"
       >
-        <p className={`
+        <p
+          className={`
           ${poppins.className}
           text-[#000]
           text-[14px]
 
           md:text-[14px]
           ${p}
-        `}>Publish</p>
+        `}
+        >
+          Publish
+        </p>
       </button>
-    )
+    );
   }
-  if( name === 'Logout'){
+  if (name === "Logout") {
     return (
-      <div className={`
+      <div
+        className={`
           w-fit
           h-fit
           relative
@@ -136,11 +157,12 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           ${button}
         `}
       >
-        <button className={`
+        <button
+          className={`
             w-fit
             h-fit
           `}
-          key='Logout Open'
+          key="Logout Open"
           onClick={() => logoutOpen()}
         >
           <Image
@@ -153,7 +175,8 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           />
         </button>
         {logoutMdFlag ? (
-          <div className={`
+          <div
+            className={`
             w-fit
             h-fit
             px-[18px]
@@ -166,15 +189,21 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
             transform
             translate-x-[-50%]
             translate-y-[calc(100%+6px)]
-          `}>
-            <p className={`
+          `}
+          >
+            <p
+              className={`
               font-[26px]
               font-semibold
               whitespace-nowrap
               text-center
               ${poppins.className}
-            `}>User name</p>
-            <button className={`
+            `}
+            >
+              User name
+            </p>
+            <button
+              className={`
                 w-fit
                 y-fit
                 px-[30px]
@@ -183,25 +212,32 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
                 bg-[rgba(255,49,49,.5)]
                 rounded-[32px]
               `}
-              key='Logout'
+              key="Logout"
               onClick={handleLogout}
             >
-              <p className={`
+              <p
+                className={`
                 font-[26px]
                 font-semibold
                 whitespace-nowrap
                 text-center
                 ${poppins.className}
-              `}>Logout</p>
+              `}
+              >
+                Logout
+              </p>
             </button>
           </div>
-        ) : (<></>)}
+        ) : (
+          <></>
+        )}
       </div>
-    )
+    );
   }
-  if( name === 'Home'){
+  if (name === "Home") {
     return (
-      <Link className={`
+      <Link
+        className={`
           w-fit
           h-fit
           bg-[#383838]
@@ -214,18 +250,22 @@ export const HeaderButton = (name: string, button?: string, p?: string) => {
           md:my-auto
           ${button}
         `}
-        key='Home'
+        key="Home"
         href="./home"
       >
-        <p className={`
+        <p
+          className={`
           ${poppins.className}
           text-white
           text-[14px]
 
           md:block
           ${p}
-        `}>Home</p>
+        `}
+        >
+          Home
+        </p>
       </Link>
-    )
+    );
   }
 };

--- a/app/create/components/ImageUploadeSection.tsx
+++ b/app/create/components/ImageUploadeSection.tsx
@@ -28,15 +28,13 @@ export default function ImageUploadeSection({
     }
   }, [uploadedImageUrl, onImageUpload]);
 
-  console.log(uploading);
-
   return (
-    <div className='mb-5'>
-      <div className='w-full h-[clamp(200px,30vw,400px)] border-2 border-dashed border-gray-300 rounded-xl flex flex-col items-center justify-center'>
-        <div className='my-8 text-7xl text-gray-300'>↑</div>
+    <div className="mb-5">
+      <div className="w-full h-[clamp(200px,30vw,400px)] border-2 border-dashed border-gray-300 rounded-xl flex flex-col items-center justify-center">
+        <div className="my-8 text-7xl text-gray-300">↑</div>
         <input
-          type='file'
-          accept='image/*'
+          type="file"
+          accept="image/*"
           onChange={handleFileChange}
           ref={fileInputRef}
           style={{ display: "none" }}
@@ -45,11 +43,11 @@ export default function ImageUploadeSection({
         <button
           onClick={handleButtonClick}
           disabled={uploading}
-          className='bg-blue-400 w-[clamp(100px,30vw,200px)] h-[clamp(40px,10vw,50px)] text-[clamp(12px,3vw,20px)] mb-5 rounded-full flex items-center justify-center'
+          className="bg-blue-400 w-[clamp(100px,30vw,200px)] h-[clamp(40px,10vw,50px)] text-[clamp(12px,3vw,20px)] mb-5 rounded-full flex items-center justify-center"
         >
           {uploading ? "uploading..." : "Upload Image"}
         </button>
-        {error && <p className='text-red-500 mt-2'>{error}</p>}
+        {error && <p className="text-red-500 mt-2">{error}</p>}
       </div>
     </div>
   );

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Header from "@/app/components/Header";
 import ImageUploadeSection from "@/app/create/components/ImageUploadeSection";
 import { supabase } from "@/app/utils/supabase";
 import dynamic from "next/dynamic";
@@ -54,50 +55,39 @@ function CreatePage() {
   };
 
   return (
-    <div className='min-h-screen flex flex-col'>
+    <div className="min-h-screen flex flex-col">
       {/* ヘッダー*/}
-      <header className='bg-gray-300 h-20 sm:h-32 md:h-40 w-full'>
-        ナビゲーションバー
-      </header>
+      <Header page="Write Blog" onClick={handleSavePost} />
       {/* コンテンツエリア */}
-      <div className='flex-grow container mx-auto'>
-        <main className='px-4'>
-          <div className='flex-grow justify-center items-center h-40'>
-            <h1 className='text-gray-300 leading-normal text-center text-4xl sm:text-5xl md:text-6xl pt-4 font-bold'>
+      <div className="flex-grow container mx-auto">
+        <main className="px-4">
+          <div className="flex-grow justify-center items-center h-40 mt-[74px] md:mt-[90px]">
+            <h1 className="text-gray-300 leading-normal text-center text-4xl sm:text-5xl md:text-6xl pt-4 font-bold">
               Create Blog
             </h1>
           </div>
-          <div className='flex flex-col lg:flex-row w-full'>
+          <div className="flex flex-col lg:flex-row w-full">
             {/* メインコンテンツ */}
-            <section className='flex-grow lg:ml-16 mr-0 lg:mr-4 order-1 lg:order-2 w-full'>
+            <section className="flex-grow lg:ml-16 mr-0 lg:mr-4 order-1 lg:order-2 w-full">
+              {error && <p className="text-red-500 mt-2">{error}</p>}
               {/* タイトル */}
-              <div className='my-10'>
+              <div className="my-10">
                 <input
-                  type='text'
+                  type="text"
                   value={title}
-                  placeholder='Title'
+                  placeholder="Title"
                   onChange={(e) => setTitle(e.target.value)}
-                  className='w-full h-12 sm:h-16 text-[clamp(36px,4.5vw,64px)] placeholder:font-bold text-gray-500 focus:outline-none'
+                  className="w-full h-12 sm:h-16 text-[clamp(36px,4.5vw,64px)] placeholder:font-bold text-gray-500 focus:outline-none"
                 />
               </div>
               {/* アップロードエリア */}
               {/* URLを設定 */}
               <ImageUploadeSection onImageUpload={handleImageUpload} />
               {/* 本文エリア */}
-              <div className='lg:mb-4'>
+              <div className="lg:mb-4">
                 {/* 本文を設定 */}
                 <QuillEditor content={content} setContent={setContent} />
               </div>
-              <div className='flex justify-end'>
-                {/* TODO:ボタンは別途共通コンポーネントを採用 */}
-                <button
-                  onClick={handleSavePost}
-                  className='bg-blue-500 text-white px-4 py-2 rounded'
-                >
-                  Save Post
-                </button>
-              </div>
-              {error && <p className='text-red-500 mt-2'>{error}</p>}
             </section>
           </div>
         </main>


### PR DESCRIPTION
close #〇〇

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- createページのヘッダーを、ヘッダーコンポーネントで使うようにしております。
  - create の page.tsx にHeader コンポーーネントを使い、props で onClick を Header > HeaderButton コンポーネントに渡しています。 
- 元々右端に仮置きしていたボタンの機能を、Header のpublishボタンに載せ替えています。

## レビュー観点（レビューをする際に見てほしい点など）

-  ブログが投稿されるか

https://github.com/user-attachments/assets/f68df90e-127e-4082-b3a6-55bf39789790





